### PR TITLE
Use jagexappletviewer.jar from oldschool.msi

### DIFF
--- a/runescape/.gitignore
+++ b/runescape/.gitignore
@@ -1,0 +1,3 @@
+bin/jagexappletviewer.jar
+rsu/3rdParty/Win32/*.dll
+share/cache/

--- a/runescape/rsu/framework/API/client/launch/updater.pm
+++ b/runescape/rsu/framework/API/client/launch/updater.pm
@@ -32,9 +32,9 @@ package client::launch::updater;
 # Fallen Unia - Zenity support  #
 #################################
 
-my $windowsurl = "http://www.runescape.com/downloads/runescape.msi";
-my $macurl = "http://www.runescape.com/downloads/runescape.dmg";
-my $jarurl = "http://www.runescape.com/downloads/jagexappletviewer.jar";
+my $windowsurl = "https://www.runescape.com/downloads/oldschool.msi";
+my $macurl = "https://www.runescape.com/downloads/runescape.dmg";
+my $jarurl = "https://www.runescape.com/downloads/jagexappletviewer.jar";
 my $updateurl = "https://github.com/HikariKnight/rsu-client/archive/rsu-api-latest.tar.gz";
 
 # Be strict to avoid messy code

--- a/runescape/rsu/framework/API/rsu/download/client.pm
+++ b/runescape/rsu/framework/API/rsu/download/client.pm
@@ -46,7 +46,7 @@ Examples:
 	result: downloads the runescape.dmg and extracts the jar file
 	
 	$ARGV[0] \"JAR/applet\" msi
-	result: downloads the runescape.msi and extracts the jar file and jawt for wine
+	result: downloads the oldschool.msi and extracts the jar file and jawt for wine
 	
 Remarks:
 	Returns nothing.
@@ -90,8 +90,13 @@ else
 	elsif (($OS =~ /(linux|MSWin32)/ && defined $ARGV[1] && $ARGV[1] =~ /^msi$/i) || ($OS =~ /(linux|MSWin32)/ && defined $ARGV[2] && $ARGV[2] =~ /^msi$/i))
 	{
 		# Download the msi file instead
-		$url = "https://www.runescape.com/downloads/runescape.msi";
+		$url = "https://www.runescape.com/downloads/oldschool.msi";
 	}
+        elsif (($OS =~ /linux/) && !defined $ARGV[1] && !defined $ARGV[2])
+        {
+                # Use the msi on linux by default
+                $url = "https://www.runescape.com/downloads/oldschool.msi";
+        }
 	
 	# Split the url by /
 	my @filename = split /\//, $url;
@@ -139,8 +144,8 @@ sub extractclient
 	# Get the client directory
 	my $clientdir = rsu::files::clientdir::getclientdir();
 	
-	# If we are not on MacOSX and the filename is runescape.msi
-	if ($filename =~ /runescape.msi/ && $OS !~ /darwin/)
+	# If we are not on MacOSX and the filename is oldschool.msi
+	if ($filename =~ /oldschool.msi/ && $OS !~ /darwin/)
 	{
 		# Run the msiextract function
 		updater::extract::client::msiextract($placejar,"true");

--- a/runescape/rsu/framework/API/rsu/download/file.pm
+++ b/runescape/rsu/framework/API/rsu/download/file.pm
@@ -24,14 +24,14 @@ NOTES:
 	it will result in \$clientdir/foldername
 
 Examples:
-	$ARGV[0] http://www.runescape.com/downloads/runescape.msi
-	result: downloads the runescape.msi to \$clientdir/.download
+	$ARGV[0] http://www.runescape.com/downloads/oldschool.msi
+	result: downloads the oldschool.msi to \$clientdir/.download
 	
-	$ARGV[0] http://www.runescape.com/downloads/runescape.msi \"/tmp\"
-	result: downloads the runescape.msi to /tmp
+	$ARGV[0] http://www.runescape.com/downloads/oldschool.msi \"/tmp\"
+	result: downloads the oldschool.msi to /tmp
 	
-	$ARGV[0] http://www.runescape.com/downloads/runescape.msi \"tmp\"
-	result: downloads the runescape.msi to \$clientdir/tmp
+	$ARGV[0] http://www.runescape.com/downloads/oldschool.msi \"tmp\"
+	result: downloads the oldschool.msi to \$clientdir/tmp
 	
 Remarks:
 	Returns nothing unless Wx is not installed.

--- a/runescape/rsu/framework/modules/updater/extract/client.pm
+++ b/runescape/rsu/framework/modules/updater/extract/client.pm
@@ -44,7 +44,7 @@ sub msiextract
 		$clientdir =~ s/\//\\/g;
 		
 		# Extract the .msi using msiexec
-		system "msiexec /a \"$clientdir\\.download\\runescape.msi\" /qn TARGETDIR=\"$clientdir\\.download\\extracted_files\"";
+		system "msiexec /a \"$clientdir\\.download\\oldschool.msi\" /qn TARGETDIR=\"$clientdir\\.download\\extracted_files\"";
 		
 		# Copy the jagexappletviewer.jar to $placejar
 		rsu::files::copy::print_cp("$clientdir/.download/extracted_files/jagexlauncher/jagexlauncher/bin/jagexappletviewer.jar", "$clientdir/$placejar/");
@@ -135,7 +135,7 @@ sub p7zip_msi
 	my ($placejar, $extractjawt) = @_;
 	
 	# Extract the msi using p7zip
-	system "cd \"$clientdir/.download/\" && 7z e -oextracted_files -y runescape.msi";
+	system "cd \"$clientdir/.download/\" && 7z e -oextracted_files -y oldschool.msi";
 	
 	# Check for the files we are looking for
 	my @files = rsu::files::grep::dirgrep("$clientdir/.download/extracted_files", "^(rslauncher|JagexAppletViewerJarFile|AWTDLLFile|JAWTDLLFile|MSVCR100DLLFile)\..+");

--- a/runescape/rsu/framework/resources/client/launch/updater/configs/buttons.conf
+++ b/runescape/rsu/framework/resources/client/launch/updater/configs/buttons.conf
@@ -1,6 +1,6 @@
 # Format is like this
 # key=buttontext;downloadurl;description
-jar_button=Update jagexappletviewer.jar;http://www.runescape.com/downloads/jagexappletviewer.jar;Download just the jagexappletviewer.jar (Recommended)\ndirectly from the RuneScape Download page
-msi_button=Update from Windows Client;http://www.runescape.com/downloads/runescape.msi;Download and extract the jar and dll files\nfrom the Official Windows Client (dll files are used for wine)
-dmg_button=Update from Mac Client;http://www.runescape.com/downloads/runescape.dmg;Download and extract the jagexappletviewer.jar\nfrom the Official Mac Client
+jar_button=Update jagexappletviewer.jar;https://www.runescape.com/downloads/jagexappletviewer.jar;Download just the jagexappletviewer.jar (Recommended)\ndirectly from the RuneScape Download page
+msi_button=Update from Windows Client;https://www.runescape.com/downloads/oldschool.msi;Download and extract the jar and dll files\nfrom the Official Windows Client (dll files are used for wine)
+dmg_button=Update from Mac Client;https://www.runescape.com/downloads/runescape.dmg;Download and extract the jagexappletviewer.jar\nfrom the Official Mac Client
 api_button=Update rsu-api;https://github.com/HikariKnight/rsu-client/archive/rsu-api-latest.tar.gz;Update the rsu-api to the newest version\n(from HikariKnight)


### PR DESCRIPTION
It seems that this jar is more up to date than the dmg and the jar download as it has the ability to remove the copyright and language settings bar after log in.

This makes sense as OSRS is probably the only thing Jagex offers that actually uses the java appletviewer, whereas RS3 is pretty much all-in on NXT.

Fixes #127 actually.

@HikariKnight 