### PR TITLE
Fix player count for OSRS and RSSFEED error

### DIFF
--- a/runescape/rsu/framework/API/client/launch/launcher.pm
+++ b/runescape/rsu/framework/API/client/launch/launcher.pm
@@ -423,13 +423,13 @@ sub set_layout
 		if ($newschannel =~ /oldschool/)
 		{
 			# Fetch rssfeed for oldschool
-			fetch_rssnews($self, "http://services.runescape.com/m=news/latest_news.rss?oldschool=true");
+			fetch_rssnews($self, "https://services.runescape.com/m=news/latest_news.rss?oldschool=true");
 		}
 		# Else
 		else
 		{
-			# Fetch rssfeed for oldschool
-			fetch_rssnews($self, "http://services.runescape.com/m=news/latest_news.rss");
+			# Fetch rssfeed for runescape
+			fetch_rssnews($self, "https://services.runescape.com/m=news/latest_news.rss");
 		}
 	}
 	
@@ -769,7 +769,7 @@ sub get_playercount
 		$osrs_playercount =~ s/.+There are currently\s(.+)\speople playing!.+/$1/;
 		
 		# If OSRS player count failed (as in we dont have a number)
-		if ($osrs_playercount !~ /^\d+$/)
+		if ($osrs_playercount !~ /^\d+,?\d+$/)
 		{
 			# Replace the OSRS playercount with 0
 			$osrs_playercount = 0;
@@ -1054,13 +1054,13 @@ sub refreshnews_clicked
 	if ($newschannel =~ /oldschool/)
 	{
 		# Refresh the rssfeed for oldschool
-		fetch_rssnews($self, "http://services.runescape.com/m=news/latest_news.rss?oldschool=true");
+		fetch_rssnews($self, "https://services.runescape.com/m=news/latest_news.rss?oldschool=true");
 	}
 	# Else
 	else
 	{
 		# Refresh the rssfeed for runescape
-		fetch_rssnews($self, "http://services.runescape.com/m=news/latest_news.rss");
+		fetch_rssnews($self, "https://services.runescape.com/m=news/latest_news.rss");
 	}
 }
 
@@ -1083,7 +1083,7 @@ sub hyperlink_clicked
 		if ($call =~ /^news:\/\/oldschool/)
 		{
 			# Refresh the rssfeed with oldschool news
-			fetch_rssnews($self, "http://services.runescape.com/m=news/latest_news.rss?oldschool=true");
+			fetch_rssnews($self, "https://services.runescape.com/m=news/latest_news.rss?oldschool=true");
 			
 			# Set the newschannel to oldschool in settings
 			rsu::files::IO::writeconf("_", "newschannel", "oldschool", "settings.conf");
@@ -1092,7 +1092,7 @@ sub hyperlink_clicked
 		elsif ($call =~ /^news:\/\/runescape/)
 		{
 			# Refresh the rssfeed with RuneScape news
-			fetch_rssnews($self, "http://services.runescape.com/m=news/latest_news.rss");
+			fetch_rssnews($self, "https://services.runescape.com/m=news/latest_news.rss");
 			
 			# Set the newschannel to oldschool in settings
 			rsu::files::IO::writeconf("_", "newschannel", "runescape", "settings.conf");


### PR DESCRIPTION
Using "http" instead of "https" will prevent the client to start and lead to the following error:

> Response from RSSFEED: IO::Socket::SSL 1.42 must be installed for https support
>
> This is the RSS contents we found:
> IO::Socket::SSL 1.42 must be installed for https support
>
> Content must be RSS|RDF|ScriptingNews|Weblog|reasonably close at /opt/runescape/rsu/framework/Perl5lib/XML/RSSLite.pm line 32.
> Compilation failed in require at (eval 53) line 1.
> BEGIN failed--compilation aborted at (eval 53) line 1.
>     ...caught at /opt/runescape/rsu/apiquery.pm line 51.